### PR TITLE
fix: add a stub URI after save w/ add-only permission

### DIFF
--- a/ios/RNCCameraRoll.mm
+++ b/ios/RNCCameraRoll.mm
@@ -209,6 +209,25 @@ RCT_EXPORT_METHOD(saveToCameraRoll:(NSURLRequest *)request
       }
     } completionHandler:^(BOOL success, NSError *error) {
       if (success) {
+        // If the write succeeded but we don't have readwrite permission, that
+        // means we have addonly permission and we cannot read the file we
+        // just created to construct a response
+        if (@available(iOS 14, *)) {
+          PHAuthorizationStatus readWriteAuthStatus = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelReadWrite];
+          if (readWriteAuthStatus != PHAuthorizationStatusAuthorized) {
+            NSDictionary *addOnlyResponse = @{
+              @"node": @{
+                @"id": placeholder.localIdentifier,
+                @"type": options[@"type"],
+                @"image": @{
+                    @"uri": @"placeholder/readWritePermissionNotGranted"
+                }
+              }
+            };
+            resolve(addOnlyResponse);
+            return;
+          }
+        }
         PHFetchOptions *options = [PHFetchOptions new];
         options.includeHiddenAssets = YES;
         options.includeAllBurstAssets = YES;


### PR DESCRIPTION
Attempting the fetch the URI of the newly-created photo requires PHOTO LIBRARY permission, which results in an unexpected permission prompt. This prevents that from happening by returning a stub URI which hopefully makes it clear why it's not a real URI.